### PR TITLE
meta: update GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: npm install --legacy-peer-deps
       - run: npm run compile
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: docs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,18 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.number }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: npm install --legacy-peer-deps
       - run: npm run compile
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: docs
           target-folder: pr/${{ github.event.number }}/
       - id: get-preview-url
         name: Get preview url
-        run: echo "::set-output name=preview-url::https://tc39.es/$(basename $GITHUB_REPOSITORY)/pr/${{ github.event.number }}"
+        run: echo "preview-url=https://tc39.es/$(basename "$GITHUB_REPOSITORY")/pr/${{ github.event.number }}" >> "$GITHUB_OUTPUT"
         shell: bash
       - name: Post Preview Comment
         uses: phulsechinmay/rewritable-pr-comment@v0.3.0


### PR DESCRIPTION
- Update actions to their latest versions.
- Use major version tags where applicable.
- Switch to the newer way of appending input to the GitHub output, instead of using the deprecated `set-output` command.